### PR TITLE
list deps: cut off the downstream parsing if Files or UpStreams is empty

### DIFF
--- a/pkg/tools/list/list.go
+++ b/pkg/tools/list/list.go
@@ -77,7 +77,7 @@ func ListDepFiles(workDir string, opt *Option) (files []string, err error) {
 //
 // Then its UpStream files/packages will be: base, base/a.k and base/b.k
 func ListUpStreamFiles(workDir string, opt *DepOptions) (deps []string, err error) {
-	if opt == nil || opt.Files == nil {
+	if opt == nil || len(opt.Files) == 0 {
 		return nil, nil
 	}
 	pkgroot, _, err := FindPkgInfo(workDir)
@@ -143,7 +143,7 @@ func ListUpStreamFiles(workDir string, opt *DepOptions) (deps []string, err erro
 // And the DownStream files/packages of the file base/a.k stays the same
 //
 func ListDownStreamFiles(workDir string, opt *DepOptions) ([]string, error) {
-	if opt == nil || opt.Files == nil || opt.UpStreams == nil {
+	if opt == nil || len(opt.Files) == 0 || len(opt.UpStreams) == 0 {
 		return nil, nil
 	}
 	pkgroot, _, err := FindPkgInfo(workDir)


### PR DESCRIPTION
<!-- Thank you for contributing to KusionStack!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kusionstack.io/docs/governance/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [X] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

pkg/tools/list/list.go
<!-- You can add the scope of this change here. 
    e.g. 
    /src/server/core.rs,
    kusionstack/KCLVM/kclvm-parser 
-->

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

minor enhancement on ListUpStreamFiles/ListDownStreamFiles API: the file parsing can be cut off when the user option values of Files/UpStreams are empty.

<!-- You can add more details here.
    e.g. 
    Call method "XXXX" to ..... in order to ....,
    More details: https://XXXX.com/doc......
-->

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [X] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [ ] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->

#### 6. Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
