### PR TITLE
fix: Broken pipe in FormatPath

### DIFF
--- a/pkg/tools/format/format_test.go
+++ b/pkg/tools/format/format_test.go
@@ -5,6 +5,7 @@ import (
 	"io/fs"
 	"io/ioutil"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,9 +38,6 @@ func TestFormatCode(t *testing.T) {
 	}
 }
 
-// TODO: fix Broken pipe in kclvm_py, see in :
-// https://github.com/KusionStack/kclvm-go/issues/75
-/*
 func TestFormatPath(t *testing.T) {
 	successDir := "testdata/success"
 	expectedFileSuffix := ".formatted"
@@ -90,7 +88,6 @@ func TestFormatPath(t *testing.T) {
 		assert.Equal(t, expected, get, fmt.Sprintf("format path get wrong result. formatted content mismatch, file: %s, expect: %s, get: %s", actualFile, expected, get))
 	}
 }
-*/
 
 type filterFile func(fs.FileInfo) bool
 


### PR DESCRIPTION
#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y 

fix #75

#### 2. What is the scope of this PR (e.g. component or file name):

KusionStack/kclvm-go/pkg/kclvm_runtime/proc.go

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

- [x] Other


#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

#### 6. Release note

Please refer to [Release Notes Language Style Guide](https://kusionstack.io/docs/governance/release-policy/) to write a quality release note.

```release-note
None
```
