### PR TITLE
Fix native API call on error inside `kclvm_service_call_with_length`

### DIFF
--- a/pkg/native/cgo.go
+++ b/pkg/native/cgo.go
@@ -85,6 +85,7 @@ func KclvmServiceCall(serv *C.kclvm_service, method *C.char, args *C.char) (*C.c
 	}
 
 	var size C.size_t
+	size = C.SIZE_MAX
 	buf := C.kclvm_service_call_with_length(serviceCall, serv, method, args, &size)
 	return buf, size
 }

--- a/pkg/native/client.go
+++ b/pkg/native/client.go
@@ -89,6 +89,11 @@ func cApiCall[I interface {
 
 	defer KclvmServiceFreeString(cOut)
 
+	if cOutSize == C.SIZE_MAX {
+		msg := C.GoString(cOut)
+		return nil, errors.New(strings.TrimPrefix(string(msg), "ERROR:"))
+	}
+
 	msg := C.GoBytes(unsafe.Pointer(cOut), C.int(cOutSize))
 
 	if bytes.HasPrefix(msg, []byte("ERROR:")) {

--- a/pkg/native/client_test.go
+++ b/pkg/native/client_test.go
@@ -84,11 +84,37 @@ func TestExecArtifactWithPlugin(t *testing.T) {
 	}
 }
 
+func TestBuildProgramError(t *testing.T) {
+	src := `
+a = 1
+  b = 2
+`
+	output := path.Join(t.TempDir(), "example")
+	client := NewNativeServiceClient()
+	// BuildProgram
+	buildResult, err := client.BuildProgram(&gpyrpc.BuildProgram_Args{
+		ExecArgs: &gpyrpc.ExecProgram_Args{
+			KFilenameList: []string{"main.k"},
+			KCodeList:     []string{src},
+		},
+		Output: output,
+	})
+	if err == nil {
+		t.Errorf("The BuildProgram should return compilation failure reason")
+	}
+	if !strings.Contains(err.Error(), "InvalidSyntax") {
+		t.Errorf("Unexpected error message: %q", err.Error())
+	}
+	if buildResult != nil {
+		t.Errorf("The BuildProgram should return nil if compilation fails")
+	}
+}
+
 func TestParseFile(t *testing.T) {
 	// Example: Test with string source
 	src := `schema Name:
     name: str
-	
+
 n = Name {name = "name"}` // Sample KCL source code
 	astJson, err := ParseFileASTJson("", src)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to KCL!

Note: 

1. With pull requests:

    - Open your pull request against "main"
    - Your pull request should have no more than two commits, if not you should squash them.
    - It should pass all tests in the available continuous integration systems such as GitHub Actions.
    - You should add/modify tests to cover your proposed code changes.
    - If your pull request contains a new feature, please document it on the README.

2. Please create an issue first to describe the problem.

    We recommend that link the issue with the PR in the following question.
    For more info, check https://kcl-lang.io/docs/community/contribute/
-->

#### 1. Does this PR affect any open issues?(Y/N) and add issue references:

- [X] N
- [ ] Y 

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

Fix #260, again

#### 2. What is the scope of this PR (e.g. component or file name):

`pkg/native`

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

<!-- You can choose a brief description here -->
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [X] Other

KCL method `kclvm_service_call_with_length` don't change `result_len` on negative scenario:
https://github.com/kcl-lang/kcl/blob/d6ba71a3118b8756bf85d29f8ac221052f893ded/kclvm/api/src/service/capi.rs#L155-L162

And returns pointer to error CString pointer without touching `result_len`.
I set `result_len` to `C.SIZE_MAX` (zero is correct protobuf message size) as CString with error marker and always return error if `result_len` was unchanged.

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [X] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [X] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other

<!-- You can add more details here.
e.g. 
The test case in XXXX is used to .....
test cases in /src/tests/XXXXX
test cases https://github.com/XXX/pull/44
benchmark stats: time XXX ms
-->
