### PR TITLE
Add function to enable formatting with dry run

### DIFF
--- a/.github/workflows/main_linux_musl.yml
+++ b/.github/workflows/main_linux_musl.yml
@@ -14,7 +14,7 @@ jobs:
           # Alpine Linux container configurations
           - os: alpine-latest
             runner: ubuntu-latest  # Host runner for the container
-            container: golang:1.24-alpine
+            container: golang:1.26-alpine
             cgo_enabled: 1
 
     runs-on: ${{ matrix.runner }}

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	google.golang.org/grpc v1.82.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
-	kcl-lang.io/lib v0.12.3
+	kcl-lang.io/lib v0.12.4
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -116,5 +116,5 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntN
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-kcl-lang.io/lib v0.12.3 h1:x/a4Nyl5Wa5gMrhu5dPLeZEho9ryXJXgHODXJ8xC9gk=
-kcl-lang.io/lib v0.12.3/go.mod h1:kK/P1DUXQD+HpdRuPMb4/f7U7Njr2q5VrihmDHjKtnw=
+kcl-lang.io/lib v0.12.4 h1:y6oa0KimtzZe+MaNd73p8b76hXcCLzD8lrZTf7gwGNc=
+kcl-lang.io/lib v0.12.4/go.mod h1:G2pPSIdu+cFb5OxiaxB0qBRIFFL598OZf1e5oiqWnns=

--- a/kcl.go
+++ b/kcl.go
@@ -68,6 +68,7 @@ type (
 	ListOptionsResult        = loader.ListOptionsResult
 	ParseProgramArgs         = parser.ParseProgramArgs
 	ParseProgramResult       = parser.ParseProgramResult
+	FormatPathOptions        = format.FormatPathOptions
 )
 
 // MustRun is like Run but panics if return any error.
@@ -167,6 +168,21 @@ func FormatCode(code any) ([]byte, error) {
 // the returned changedPaths are the changed file paths (relative path)
 func FormatPath(path string) (changedPaths []string, err error) {
 	return format.FormatPath(path)
+}
+
+// FormatPathWithOptions formats files from the given path with some options.
+// path:
+// if path is `.` or empty string, all KCL files in current directory will be formatted, not recursively
+// if path is `path/file.k`, the specified KCL file will be formatted
+// if path is `path/to/dir`, all KCL files in the specified dir will be formatted, not recursively
+// if path is `path/to/dir/...`, all KCL files in the specified dir will be formatted recursively
+//
+// the returned changedPaths are the changed file paths (relative path)
+func FormatPathWithOptions(
+	path string,
+	opts FormatPathOptions,
+) ([]string, error) {
+	return format.FormatPathWithOptions(path, opts)
 }
 
 // ListDepFiles return the depend files from the given path

--- a/pkg/tools/format/format_test.go
+++ b/pkg/tools/format/format_test.go
@@ -98,6 +98,39 @@ func TestFormatPath(t *testing.T) {
 	}
 }
 
+func TestFormatPathWithOptions(t *testing.T) {
+	successDir := filepath.Join("testdata", "success")
+
+	sourceFiles := findFiles(t, successDir, func(info fs.DirEntry) bool {
+		return strings.HasSuffix(info.Name(), ".k")
+	})
+	var sourceFilesBackup []kclFile
+
+	for _, sourceFile := range sourceFiles {
+		content, err := os.ReadFile(sourceFile)
+		if err != nil {
+			t.Fatalf("read source file content failed: %s", sourceFile)
+		}
+		sourceFilesBackup = append(sourceFilesBackup, kclFile{
+			name:    sourceFile,
+			content: content,
+		})
+	}
+
+	_, err := FormatPathWithOptions(successDir, FormatPathOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("format path exec failed. %v", err)
+	}
+
+	for _, sourceFile := range sourceFilesBackup {
+		newContent, err := os.ReadFile(sourceFile.name)
+		if err != nil {
+			t.Fatalf("read source file content failed: %s", sourceFile.name)
+		}
+		assert.Equal(t, sourceFile.content, newContent, fmt.Sprintf("format path with dry run should not modify files, file: %s, expect: %s, get: %s", sourceFile.name, sourceFile.content, newContent))
+	}
+}
+
 type filterFile func(fs.DirEntry) bool
 
 func findFiles(t testing.TB, testDir string, filter filterFile) (names []string) {
@@ -122,7 +155,7 @@ type kclFile struct {
 
 func writeFile(t *testing.T, kclfiles []kclFile) {
 	for _, backUpFile := range kclfiles {
-		err := os.WriteFile(backUpFile.name, backUpFile.content, 0666)
+		err := os.WriteFile(backUpFile.name, backUpFile.content, 0o666)
 		if err != nil {
 			t.Logf("write back formatted source file failed: %v", err)
 		}

--- a/pkg/tools/format/kformat.go
+++ b/pkg/tools/format/kformat.go
@@ -36,13 +36,25 @@ func FormatCode(code any) ([]byte, error) {
 	return resp.Formatted, nil
 }
 
-func FormatPath(path string) (changedPaths []string, err error) {
+type FormatPathOptions struct {
+	DryRun bool
+}
+
+func FormatPathWithOptions(
+	path string,
+	opts FormatPathOptions,
+) ([]string, error) {
 	svc := kcl.Service()
 	resp, err := svc.FormatPath(&gpyrpc.FormatPathArgs{
-		Path: path,
+		Path:   path,
+		DryRun: opts.DryRun,
 	})
 	if err != nil {
 		return nil, err
 	}
 	return resp.ChangedPaths, nil
+}
+
+func FormatPath(path string) ([]string, error) {
+	return FormatPathWithOptions(path, FormatPathOptions{})
 }

--- a/pkg/tools/format/testdata/success/person.formatted
+++ b/pkg/tools/format/testdata/success/person.formatted
@@ -1,3 +1,2 @@
 schema Person:
     name: str
-


### PR DESCRIPTION

#### 1. Does this PR affect any open issues?(Y/N) and add issue references (e.g. "fix #123", "re #123".):

- [ ] N
- [x] Y kcl-lang/kcl#2101

<!-- You can add issue references here. 
    e.g. 
    fix #123, re #123, 
    fix https://github.com/XXX/issues/44
-->

#### 2. What is the scope of this PR (e.g. component or file name):

The format tool.

#### 3. Provide a description of the PR(e.g. more details, effects, motivations or doc link):

I added a function for formatting that can be called with options in order to both support formatting with dry run, and to ensure that the existing API is stable (did not change the existing function).

#### 4. Are there any breaking changes?(Y/N) and describe the breaking changes(e.g. more details, motivations or doc link):

- [x] N
- [ ] Y 

<!-- You can add more details here.
    e.g. 
    Calling method "XXXX" will cause the "XXXX", "XXXX" modules to be affected.
    More details: https://XXXX.com/doc......
-->

#### 5. Are there test cases for these changes?(Y/N) select and add more details, references or doc links:

<!-- You can choose a brief description here -->
- [x] Unit test
- [ ] Integration test
- [ ] Benchmark (add benchmark stats below)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] Other
