### PR TITLE
fix(validate): forward external KCL packages to ValidateCodeArgs

### DIFF
--- a/pkg/tools/validate/test_data/external/ext/kcl.mod
+++ b/pkg/tools/validate/test_data/external/ext/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "ext"
+edition = "v0.11.0"
+version = "0.0.1"

--- a/pkg/tools/validate/test_data/external/ext/main.k
+++ b/pkg/tools/validate/test_data/external/ext/main.k
@@ -1,0 +1,2 @@
+schema Value:
+    value: str

--- a/pkg/tools/validate/test_data/external/with_ext/data.json
+++ b/pkg/tools/validate/test_data/external/with_ext/data.json
@@ -1,0 +1,6 @@
+{
+    "name": "Alice",
+    "payload": {
+        "value": "v1"
+    }
+}

--- a/pkg/tools/validate/test_data/external/with_ext/kcl.mod
+++ b/pkg/tools/validate/test_data/external/with_ext/kcl.mod
@@ -1,0 +1,4 @@
+[package]
+name = "with_ext"
+edition = "v0.11.0"
+version = "0.0.1"

--- a/pkg/tools/validate/test_data/external/with_ext/schema.k
+++ b/pkg/tools/validate/test_data/external/with_ext/schema.k
@@ -1,0 +1,8 @@
+import ext
+
+schema Holder:
+    name: str
+    payload: ext.Value
+
+    check:
+        name != ""

--- a/pkg/tools/validate/validate.go
+++ b/pkg/tools/validate/validate.go
@@ -10,11 +10,56 @@ import (
 	"kcl-lang.io/kcl-go/pkg/spec/gpyrpc"
 )
 
+// ExternalPackage is a single mapping from a KCL package name to its
+// on-disk path, in the same format accepted by the `kcl run --external`
+// flag. Each entry is forwarded to the KCL core service as an
+// `ExternalPkg` argument so the validator can resolve external schemas
+// referenced by the file being validated.
+type ExternalPackage struct {
+	// PkgName is the imported KCL package name (e.g. "k8s" or "ext").
+	PkgName string
+	// PkgPath is the path on disk where the package source lives.
+	PkgPath string
+}
+
 // ValidateOptions represents the options for the Validate function.
 type ValidateOptions struct {
 	Schema        string // The schema to validate against.
 	AttributeName string // The attribute name to validate.
 	Format        string // The format of the data.
+	// ExternalPackages is an optional list of external KCL packages the
+	// validated file may depend on. Each entry maps a package name (as
+	// used in `import <name>` statements) to its location on disk, so
+	// the validator can resolve those imports during type checking.
+	// When this list is empty the validator falls back to the
+	// historical single-file behaviour and any unresolved external
+	// import will surface as a `CannotFindModule` error, matching
+	// pre-existing semantics.
+	ExternalPackages []ExternalPackage
+}
+
+// toExternalPkgs converts the high-level ExternalPackage list into the
+// gRPC representation expected by the KCL service. The result is nil
+// when no packages were provided so that the gRPC payload stays as
+// compact as before for callers that do not need this feature.
+func (o *ValidateOptions) toExternalPkgs() []*gpyrpc.ExternalPkg {
+	if o == nil || len(o.ExternalPackages) == 0 {
+		return nil
+	}
+	out := make([]*gpyrpc.ExternalPkg, 0, len(o.ExternalPackages))
+	for _, pkg := range o.ExternalPackages {
+		if pkg.PkgName == "" || pkg.PkgPath == "" {
+			continue
+		}
+		out = append(out, &gpyrpc.ExternalPkg{
+			PkgName: pkg.PkgName,
+			PkgPath: pkg.PkgPath,
+		})
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // Validate validates the given data file against the specified
@@ -34,6 +79,7 @@ func Validate(dataFile, schemaFile string, opts *ValidateOptions) (ok bool, err 
 		Schema:        opts.Schema,
 		AttributeName: opts.AttributeName,
 		Format:        opts.Format,
+		ExternalPkgs:  opts.toExternalPkgs(),
 	})
 	if err != nil {
 		return false, err
@@ -45,6 +91,11 @@ func Validate(dataFile, schemaFile string, opts *ValidateOptions) (ok bool, err 
 	return resp.Success, e
 }
 
+// ValidateCode validates the given in-memory data string against the
+// provided in-memory schema code, with the given options. This is
+// intended for callers that already hold the schema and data as
+// strings (for example, a code editor performing live validation);
+// callers passing files on disk should prefer [Validate].
 func ValidateCode(data, code string, opts *ValidateOptions) (ok bool, err error) {
 	if opts == nil {
 		opts = &ValidateOptions{}
@@ -56,6 +107,7 @@ func ValidateCode(data, code string, opts *ValidateOptions) (ok bool, err error)
 		Schema:        opts.Schema,
 		AttributeName: opts.AttributeName,
 		Format:        opts.Format,
+		ExternalPkgs:  opts.toExternalPkgs(),
 	})
 	if err != nil {
 		return false, err
@@ -67,6 +119,10 @@ func ValidateCode(data, code string, opts *ValidateOptions) (ok bool, err error)
 	return resp.Success, e
 }
 
+// ValidateCodeFile validates the data read from `dataFile` against the
+// given schema source. Both the data and code can also be supplied
+// directly via `data`/`code`; when `dataFile` is non-empty it takes
+// precedence over `data` and the contents of the file are read.
 func ValidateCodeFile(dataFile, data, code string, opts *ValidateOptions) (ok bool, err error) {
 	if opts == nil {
 		opts = &ValidateOptions{}
@@ -79,6 +135,7 @@ func ValidateCodeFile(dataFile, data, code string, opts *ValidateOptions) (ok bo
 		Schema:        opts.Schema,
 		AttributeName: opts.AttributeName,
 		Format:        opts.Format,
+		ExternalPkgs:  opts.toExternalPkgs(),
 	})
 	if err != nil {
 		return false, err

--- a/pkg/tools/validate/validate_test.go
+++ b/pkg/tools/validate/validate_test.go
@@ -62,3 +62,63 @@ schema Person:
 		t.Fatalf("expect validation error, got %s", err.Error())
 	}
 }
+
+// TestValidateWithExternalPackages is a regression test for
+// https://github.com/kcl-lang/kcl/issues/1877. It ensures that when the
+// caller supplies an `ExternalPackages` mapping, the validator can
+// resolve imports to schemas declared in those external packages and
+// validate data against the resulting type.
+func TestValidateWithExternalPackages(t *testing.T) {
+	opts := &ValidateOptions{
+		ExternalPackages: []ExternalPackage{
+			{
+				PkgName: "ext",
+				PkgPath: "./test_data/external/ext",
+			},
+		},
+	}
+	ok, err := Validate(
+		"./test_data/external/with_ext/data.json",
+		"./test_data/external/with_ext/schema.k",
+		opts,
+	)
+	if err != nil {
+		t.Fatalf("expected validation success, got error: %v", err)
+	}
+	if !ok {
+		t.Fatalf("expected validation success, got failure")
+	}
+}
+
+// TestValidateWithoutExternalPackagesReportsMissingImport ensures the
+// historical behaviour is preserved when the caller does not supply an
+// `ExternalPackages` mapping: an unresolved external import surfaces as
+// a `Cannot find the module` error rather than silently passing.
+func TestValidateWithoutExternalPackagesReportsMissingImport(t *testing.T) {
+	_, err := Validate(
+		"./test_data/external/with_ext/data.json",
+		"./test_data/external/with_ext/schema.k",
+		nil,
+	)
+	if err == nil {
+		t.Fatalf("expected validation error for unresolved import, got nil")
+	}
+	if !strings.Contains(err.Error(), "ext") {
+		t.Fatalf("expected error to mention missing 'ext' package, got: %v", err)
+	}
+}
+
+// TestExternalPackagesWithEmptyEntriesIgnored verifies that the
+// conversion helper drops empty entries rather than forwarding them to
+// the gRPC service, which would otherwise produce confusing errors.
+func TestExternalPackagesWithEmptyEntriesIgnored(t *testing.T) {
+	opts := &ValidateOptions{
+		ExternalPackages: []ExternalPackage{
+			{PkgName: "", PkgPath: "./test_data/external/ext"},
+			{PkgName: "ext", PkgPath: ""},
+		},
+	}
+	if got := opts.toExternalPkgs(); got != nil {
+		t.Fatalf("expected nil gRPC list when only empty entries are provided, got %v", got)
+	}
+}


### PR DESCRIPTION
Fixes kcl-lang/kcl#1877.

The Go SDK's `validate.ValidateOptions` struct had no field for
external KCL package mappings, so `Validate`, `ValidateCode`, and
`ValidateCodeFile` silently dropped them on the way to the gRPC
service. As a result, `kcl vet` could not validate data against a
schema that imported another KCL package even though the underlying
Rust service (`kcl-lang/kcl`) already supports external packages
via `external_pkgs`.

## Changes

- Add a new `ExternalPackage` struct (`PkgName`, `PkgPath`) plus an
  `ExternalPackages` slice on `validate.ValidateOptions`.
- Forward the slice to `ValidateCodeArgs.ExternalPkgs` from
  `Validate`, `ValidateCode`, and `ValidateCodeFile`.
- Skip entries with empty name or path so they do not reach the gRPC
  layer with confusing errors.

## Tests

- `TestValidateWithExternalPackages` — verifies a schema importing
  another package validates successfully when the package mapping
  is supplied.
- `TestValidateWithoutExternalPackagesReportsMissingImport` —
  confirms the historical "Cannot find the module" behaviour is
  preserved when the caller does not provide the mapping.
- `TestExternalPackagesWithEmptyEntriesIgnored` — covers the
  empty-entry short-circuit in `toExternalPkgs`.

New test fixtures live under `pkg/tools/validate/test_data/external/`
(`ext/` is the imported package, `with_ext/` is the schema under
test).

Depends on / coordinates with kcl-lang/cli#X (the CLI side that
exposes `--external`).