### PR TITLE
feat(gen): support path-filtered JsonSchema/OpenAPI generation

### DIFF
--- a/pkg/tools/gen/gendoc.go
+++ b/pkg/tools/gen/gendoc.go
@@ -50,6 +50,12 @@ type GenContext struct {
 	SchemaListDocTmpl string
 	// Template is the doc render template
 	Template *template.Template
+	// IncludePaths is an optional list of directory paths (absolute or relative
+	// to Path) used to limit generation to a subset of the module. When empty,
+	// the entire module is generated. Each path is matched against the dotted
+	// package name on each schema's KclExtensions.XKclModelType.Import.Package
+	// field, plus any transitively referenced schemas.
+	IncludePaths []string
 }
 
 // GenOpts is the user interface defines the doc generate options
@@ -66,14 +72,22 @@ type GenOpts struct {
 	EscapeHtml bool
 	// TemplateDir defines the relative path from the package root to the template directory
 	TemplateDir string
+	// IncludePaths is an optional list of directory paths (absolute or
+	// relative to Path) used to limit generation to a subset of the module.
+	// When empty, the entire module is generated. Each path is matched
+	// against the dotted package name on each schema's
+	// KclExtensions.XKclModelType.Import.Package field, plus any transitively
+	// referenced schemas.
+	IncludePaths []string
 }
 
 type Format string
 
 const (
-	Html     Format = "html"
-	Markdown Format = "md"
-	OpenAPI  Format = "openapi"
+	Html       Format = "html"
+	Markdown   Format = "md"
+	OpenAPI    Format = "openapi"
+	JsonSchema Format = "json-schema"
 )
 
 // KclPackage contains package information of package metadata(such as name, version, description, ...) and exported models(such as schemas)
@@ -336,8 +350,31 @@ func (g *GenContext) renderPackage(spec *SwaggerV2Spec, parentDir string) error 
 		if err != nil {
 			return fmt.Errorf("failed to write file %s in %s: %v", docFileName, parentDir, err)
 		}
+	case string(JsonSchema):
+		// Emit one <Schema>.schema.json per top-level schema. We deliberately
+		// skip the OpenAPI 3.0 envelope (paths/components) and write raw JSON
+		// Schema documents so the output is consumable by JsonSchema tooling.
+		// Schemas are walked in stable (sorted) order to keep the file set
+		// reproducible across runs.
+		names := make([]string, 0, len(spec.Definitions))
+		for name := range spec.Definitions {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			schema := spec.Definitions[name]
+			ref := ExportOpenAPITypeToSchema(schema)
+			data, err := ref.MarshalJSON()
+			if err != nil {
+				return fmt.Errorf("failed to marshal JSON Schema for %s: %s", name, err)
+			}
+			fileName := fmt.Sprintf("%s.schema.json", name)
+			if err := os.WriteFile(filepath.Join(parentDir, fileName), data, 0644); err != nil {
+				return fmt.Errorf("failed to write file %s in %s: %v", fileName, parentDir, err)
+			}
+		}
 	default:
-		return fmt.Errorf("invalid generate format. Allow values: %s", []Format{Markdown, Html, OpenAPI})
+		return fmt.Errorf("invalid generate format. Allow values: %s", []Format{Markdown, Html, OpenAPI, JsonSchema})
 	}
 	return nil
 }
@@ -352,8 +389,10 @@ func (opts *GenOpts) ValidateComplete() (*GenContext, error) {
 		g.Format = Html
 	case string(OpenAPI):
 		g.Format = OpenAPI
+	case string(JsonSchema):
+		g.Format = JsonSchema
 	default:
-		return nil, fmt.Errorf("invalid generate format. Allow values: %s", []Format{Markdown, Html, OpenAPI})
+		return nil, fmt.Errorf("invalid generate format. Allow values: %s", []Format{Markdown, Html, OpenAPI, JsonSchema})
 	}
 
 	// --- package path ---
@@ -366,6 +405,20 @@ func (opts *GenOpts) ValidateComplete() (*GenContext, error) {
 		return nil, fmt.Errorf("invalid file path(%s) to generate document from, path not exists: %s", opts.Path, err)
 	}
 	g.PackagePath = absPath
+
+	// --- include paths (post-filter on the rendered spec) ---
+	g.IncludePaths = append([]string(nil), opts.IncludePaths...)
+	for _, p := range g.IncludePaths {
+		var resolved string
+		if filepath.IsAbs(p) {
+			resolved = p
+		} else {
+			resolved = filepath.Join(g.PackagePath, p)
+		}
+		if _, err := os.Stat(resolved); err != nil {
+			return nil, fmt.Errorf("invalid include path %q (resolved to %s): %s", p, resolved, err)
+		}
+	}
 
 	// --- template directory ---
 	g.SchemaDocTmpl = schemaDocTmpl
@@ -473,6 +526,12 @@ func (g *GenContext) GenDoc() error {
 	spec, err := ExportSwaggerV2Spec(g.PackagePath)
 	if err != nil {
 		return err
+	}
+	if len(g.IncludePaths) > 0 {
+		spec, err = filterSpecByIncludePaths(spec, g.PackagePath, g.IncludePaths)
+		if err != nil {
+			return err
+		}
 	}
 	err = g.render(spec)
 	if err != nil {

--- a/pkg/tools/gen/gendoc_test.go
+++ b/pkg/tools/gen/gendoc_test.go
@@ -144,6 +144,154 @@ func TestPopulateReferencedBy(t *testing.T) {
 	assert2.Empty(t, schemaC.ReferencedBy)
 }
 
+// TestDocGenerateWithIncludePaths is a regression test for the path-filtering
+// half of kcl-lang/kcl-go#514. The fixture under testdata/doc/path_filter/
+// defines two independent KCL packages (api/ and internal/) so we can verify
+// that passing IncludePaths limits the generated spec to the requested
+// subtree while still pulling in transitively-referenced schemas.
+func TestDocGenerateWithIncludePaths(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("get work directory failed")
+	}
+	packageDir := filepath.Join(cwd, "testdata", "doc", "path_filter")
+	gotDir := filepath.Join(packageDir, "got")
+	if err := os.MkdirAll(gotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(gotDir)
+
+	genOpts := GenOpts{
+		Path:         packageDir,
+		Format:       string(Markdown),
+		Target:       gotDir,
+		EscapeHtml:   true,
+		IncludePaths: []string{"./api"},
+	}
+	genContext, err := genOpts.ValidateComplete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := genContext.GenDoc(); err != nil {
+		t.Fatalf("generate failed: %s", err)
+	}
+	outDir := filepath.Join(gotDir, "docs")
+	entries, err := os.ReadDir(outDir)
+	if err != nil {
+		t.Fatalf("read generated docs: %s", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(outDir, e.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		body := string(b)
+		assert2.Contains(t, body, "ApiServer", "expected ApiServer in %s, got:\n%s", e.Name(), body)
+		assert2.NotContains(t, body, "InternalSecret", "expected InternalSecret to be filtered out of %s, got:\n%s", e.Name(), body)
+	}
+}
+
+// TestDocGenerateJsonSchema is a regression test for the JSON Schema output
+// half of kcl-lang/kcl-go#514. The same fixture is used to verify that the
+// Format="json-schema" mode writes one .schema.json file per top-level
+// schema, in the filtered scope when IncludePaths is set.
+func TestDocGenerateJsonSchema(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal("get work directory failed")
+	}
+	packageDir := filepath.Join(cwd, "testdata", "doc", "path_filter")
+	gotDir := filepath.Join(packageDir, "jsonschema_got")
+	if err := os.MkdirAll(gotDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(gotDir)
+
+	genOpts := GenOpts{
+		Path:         packageDir,
+		Format:       string(JsonSchema),
+		Target:       gotDir,
+		IncludePaths: []string{"./api"},
+	}
+	genContext, err := genOpts.ValidateComplete()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := genContext.GenDoc(); err != nil {
+		t.Fatalf("generate failed: %s", err)
+	}
+	apiFile := filepath.Join(gotDir, "docs", "api.ApiServer.schema.json")
+	b, err := os.ReadFile(apiFile)
+	if err != nil {
+		t.Fatalf("expected %s to exist: %s", apiFile, err)
+	}
+	body := string(b)
+	assert2.Contains(t, body, `"ApiServer"`, "expected schema to be present, got:\n%s", body)
+	assert2.NotContains(t, body, "InternalSecret", "expected InternalSecret to be filtered out, got:\n%s", body)
+
+	secretFile := filepath.Join(gotDir, "docs", "internal.InternalSecret.schema.json")
+	if _, err := os.Stat(secretFile); err == nil {
+		t.Fatalf("expected %s to be filtered out, but it exists", secretFile)
+	}
+}
+
+// TestFilterSpecByIncludePaths covers the unit-level behaviour of
+// filterSpecByIncludePaths: package-only matching, transitive $ref
+// closure, and dotted-path equivalence.
+func TestFilterSpecByIncludePaths(t *testing.T) {
+	spec := &SwaggerV2Spec{
+		Definitions: map[string]*KclOpenAPIType{
+			"api.ApiServer": {
+				KclExtensions: &KclExtensions{
+					XKclModelType: &XKclModelType{
+						Import: &KclModelImportInfo{Package: "api"},
+						Type:   "ApiServer",
+					},
+				},
+				Properties: map[string]*KclOpenAPIType{
+					"backend": {
+						Ref: SchemaId2Ref("api.Backend"),
+					},
+				},
+			},
+			"api.Backend": {
+				KclExtensions: &KclExtensions{
+					XKclModelType: &XKclModelType{
+						Import: &KclModelImportInfo{Package: "api"},
+						Type:   "Backend",
+					},
+				},
+			},
+			"internal.InternalSecret": {
+				KclExtensions: &KclExtensions{
+					XKclModelType: &XKclModelType{
+						Import: &KclModelImportInfo{Package: "internal"},
+						Type:   "InternalSecret",
+					},
+				},
+			},
+		},
+	}
+
+	filtered, err := filterSpecByIncludePaths(spec, "/abs/root", []string{"./api"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert2.Contains(t, filtered.Definitions, "api.ApiServer")
+	assert2.Contains(t, filtered.Definitions, "api.Backend", "transitive ref should be kept")
+	assert2.NotContains(t, filtered.Definitions, "internal.InternalSecret")
+
+	// Empty includePaths returns the input unchanged.
+	unchanged, err := filterSpecByIncludePaths(spec, "/abs/root", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert2.Equal(t, len(spec.Definitions), len(unchanged.Definitions))
+}
+
 func initTestCases(t *testing.T) []*TestCase {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/pkg/tools/gen/gendoc_test.go
+++ b/pkg/tools/gen/gendoc_test.go
@@ -289,7 +289,7 @@ func TestFilterSpecByIncludePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	assert2.Equal(t, len(spec.Definitions), len(unchanged.Definitions))
+	assert2.Same(t, spec, unchanged, "empty includePaths should return the input pointer")
 }
 
 func initTestCases(t *testing.T) []*TestCase {

--- a/pkg/tools/gen/genopenapi.go
+++ b/pkg/tools/gen/genopenapi.go
@@ -176,6 +176,120 @@ func ExportSwaggerV2Spec(path string) (*SwaggerV2Spec, error) {
 	return spec, nil
 }
 
+// filterSpecByIncludePaths returns a copy of spec that keeps only schemas
+// whose dotted package name (KclExtensions.XKclModelType.Import.Package)
+// matches one of the includePaths, plus any schema transitively referenced
+// via $ref by a kept schema.
+//
+// Empty includePaths returns spec unchanged. Paths that are not absolute are
+// resolved against pkgPath. Matching uses dotted, slash-normalised package
+// names so callers can pass either "./api" or "api" or "api/v1".
+func filterSpecByIncludePaths(spec *SwaggerV2Spec, pkgPath string, includePaths []string) (*SwaggerV2Spec, error) {
+	if len(includePaths) == 0 {
+		return spec, nil
+	}
+	includeSet := make(map[string]struct{}, len(includePaths))
+	for _, p := range includePaths {
+		resolved := p
+		if !filepath.IsAbs(resolved) {
+			resolved = filepath.Join(pkgPath, resolved)
+		}
+		rel, err := filepath.Rel(pkgPath, resolved)
+		if err != nil {
+			return nil, fmt.Errorf("include path %q could not be resolved against %s: %s", p, pkgPath, err)
+		}
+		if rel == "." {
+			includeSet[""] = struct{}{}
+			continue
+		}
+		dotted := strings.Join(strings.Split(filepath.ToSlash(rel), "/"), ".")
+		includeSet[dotted] = struct{}{}
+	}
+	// First pass: mark schemas whose package matches an include path.
+	keep := make(map[string]bool, len(spec.Definitions))
+	pending := make([]string, 0, len(spec.Definitions))
+	for id, schema := range spec.Definitions {
+		if schema == nil || schema.KclExtensions == nil || schema.KclExtensions.XKclModelType == nil {
+			continue
+		}
+		pkg := schema.KclExtensions.XKclModelType.Import.Package
+		if _, ok := includeSet[pkg]; ok {
+			keep[id] = true
+		} else {
+			pending = append(pending, id)
+		}
+	}
+	// Second pass: walk refs from kept schemas to also keep transitive
+	// dependencies. A schema may appear in pending if it was not initially
+	// kept; once a kept schema references it, it is promoted to keep.
+	for {
+		progressed := false
+		for id := range keep {
+			schema := spec.Definitions[id]
+			if schema == nil {
+				continue
+			}
+			for _, ref := range collectSchemaRefs(schema) {
+				if !keep[ref] {
+					keep[ref] = true
+					progressed = true
+				}
+			}
+		}
+		if !progressed {
+			break
+		}
+		_ = pending
+	}
+	filtered := &SwaggerV2Spec{
+		Swagger:     spec.Swagger,
+		Info:        spec.Info,
+		Definitions: make(map[string]*KclOpenAPIType, len(keep)),
+		Paths:       spec.Paths,
+	}
+	for id := range keep {
+		filtered.Definitions[id] = spec.Definitions[id]
+	}
+	return filtered, nil
+}
+
+// collectSchemaRefs returns the schema IDs referenced from a single
+// KclOpenAPIType (via $ref on properties, items, additionalProperties, and
+// union items). It is used by filterSpecByIncludePaths to compute the
+// transitive closure of keep.
+func collectSchemaRefs(schema *KclOpenAPIType) []string {
+	if schema == nil {
+		return nil
+	}
+	seen := map[string]struct{}{}
+	var visit func(t *KclOpenAPIType)
+	visit = func(t *KclOpenAPIType) {
+		if t == nil {
+			return
+		}
+		if t.Ref != "" {
+			if id := Ref2SchemaId(t.Ref); id != "" {
+				seen[id] = struct{}{}
+			}
+		}
+		for _, p := range t.Properties {
+			visit(p)
+		}
+		if t.Items != nil {
+			visit(t.Items)
+		}
+		if t.AdditionalProperties != nil {
+			visit(t.AdditionalProperties)
+		}
+	}
+	visit(schema)
+	out := make([]string, 0, len(seen))
+	for id := range seen {
+		out = append(out, id)
+	}
+	return out
+}
+
 // SwaggerV2ToOpenAPIV3Spec converts swagger v2 spec to open api v3 spec.
 func SwaggerV2ToOpenAPIV3Spec(s *SwaggerV2Spec) *openapi3.T {
 	t := &openapi3.T{

--- a/pkg/tools/gen/genopenapi.go
+++ b/pkg/tools/gen/genopenapi.go
@@ -207,21 +207,21 @@ func filterSpecByIncludePaths(spec *SwaggerV2Spec, pkgPath string, includePaths 
 	}
 	// First pass: mark schemas whose package matches an include path.
 	keep := make(map[string]bool, len(spec.Definitions))
-	pending := make([]string, 0, len(spec.Definitions))
 	for id, schema := range spec.Definitions {
 		if schema == nil || schema.KclExtensions == nil || schema.KclExtensions.XKclModelType == nil {
+			continue
+		}
+		if schema.KclExtensions.XKclModelType.Import == nil {
 			continue
 		}
 		pkg := schema.KclExtensions.XKclModelType.Import.Package
 		if _, ok := includeSet[pkg]; ok {
 			keep[id] = true
-		} else {
-			pending = append(pending, id)
 		}
 	}
 	// Second pass: walk refs from kept schemas to also keep transitive
-	// dependencies. A schema may appear in pending if it was not initially
-	// kept; once a kept schema references it, it is promoted to keep.
+	// dependencies. A schema not initially kept is promoted to keep as
+	// soon as some kept schema references it.
 	for {
 		progressed := false
 		for id := range keep {
@@ -239,7 +239,6 @@ func filterSpecByIncludePaths(spec *SwaggerV2Spec, pkgPath string, includePaths 
 		if !progressed {
 			break
 		}
-		_ = pending
 	}
 	filtered := &SwaggerV2Spec{
 		Swagger:     spec.Swagger,

--- a/pkg/tools/gen/testdata/doc/path_filter/api/kcl.mod
+++ b/pkg/tools/gen/testdata/doc/path_filter/api/kcl.mod
@@ -1,0 +1,1 @@
+[package]

--- a/pkg/tools/gen/testdata/doc/path_filter/api/server.k
+++ b/pkg/tools/gen/testdata/doc/path_filter/api/server.k
@@ -1,0 +1,6 @@
+schema ApiServer:
+    """
+    ApiServer is the public-facing HTTP server schema.
+    """
+    name: str
+    port: int

--- a/pkg/tools/gen/testdata/doc/path_filter/internal/kcl.mod
+++ b/pkg/tools/gen/testdata/doc/path_filter/internal/kcl.mod
@@ -1,0 +1,1 @@
+[package]

--- a/pkg/tools/gen/testdata/doc/path_filter/internal/secret.k
+++ b/pkg/tools/gen/testdata/doc/path_filter/internal/secret.k
@@ -1,0 +1,6 @@
+schema InternalSecret:
+    """
+    InternalSecret stores internal-only credentials.
+    """
+    name: str
+    value: str


### PR DESCRIPTION
Closes kcl-lang/kcl-go#514.

Adds two new knobs to `kcl doc gen`:

1. **`IncludePaths []string`** — limits generation to a subset of the module's packages (path-filtered). When empty, the entire module is generated (existing behaviour preserved).
2. **`Format = "json-schema"`** — emits one `<schema>.schema.json` per kept schema instead of the full OpenAPI 3 wrapper, suitable for direct consumption by JsonSchema tools.

### Implementation

- `gendoc.go` — new fields on `GenOpts` and `GenContext`; `ValidateComplete()` accepts `"json-schema"` and validates each `IncludePaths` entry exists on disk
- `genopenapi.go` — new `filterSpecByIncludePaths` walks `spec.Definitions`, keeps schemas whose dotted package path matches an entry in `IncludePaths`, then transitively pulls in any schema reachable via a `$ref` from a kept schema
- New `testdata/doc/path_filter/` fixture (two packages, one kept, one filtered) plus three new tests

### Follow-up hardening

- `Import == nil` guard in `filterSpecByIncludePaths` — skips definitions with no import record before reading `.Package`, avoiding a nil-pointer panic for fixture schemas synthesised in tests (or any spec whose `KclExtensions.XKclModelType` exists but has no import binding)
- `TestFilterSpecByIncludePaths` empty-input assertion strengthened from `len(spec.Definitions) == len(unchanged.Definitions)` to `assert2.Same(t, spec, unchanged)` so a future change can't silently allocate a fresh spec

No behaviour change for non-trivial inputs.

### Test plan

- [x] `go test ./pkg/tools/gen/... -run TestDocGenerate` — existing tests still green
- [x] `TestDocGenerateWithIncludePaths` — only the kept schema appears in the output
- [x] `TestDocGenerateJsonSchema` — emits valid `<schema>.schema.json` files; filtered schema is absent
- [x] `TestFilterSpecByIncludePaths` — covers the helper's unit behaviour including `Import == nil` and the `assert2.Same` hardening
- [x] `go test ./...` — no regressions