### PR TITLE
fix(gen): stop golden walker from claiming the cross_pkg fixture

### DIFF
--- a/pkg/tools/gen/genkcl_test.go
+++ b/pkg/tools/gen/genkcl_test.go
@@ -217,6 +217,12 @@ func TestGenKclFromGoStruct(t *testing.T) {
 		if !caseFile.IsDir() {
 			continue
 		}
+		// Only pick up cases following the input.go/expect.k convention.
+		// Fixtures with a different layout (e.g. cross_pkg, which needs
+		// non-default options) have their own dedicated tests.
+		if _, err := os.Stat(filepath.Join(casesPath, caseFile.Name(), "input.go")); err != nil {
+			continue
+		}
 		caseFile := caseFile // capture for closure
 		t.Run(caseFile.Name(), func(t *testing.T) {
 			input := "./" + filepath.Join(casesPath, caseFile.Name())


### PR DESCRIPTION
## Summary

`main` is red on all four `build-and-test` jobs (linux, linux-musl, macos, windows) since #577. CodeQL is unaffected. This restores green.

**Root cause is a merge race between two individually-green PRs merged 90 seconds apart:**

- #575 added `GenKclOptions.OneFile *bool` plus the `testdata/gostruct/cross_pkg/` fixture. Its `expect.k` captures the **`OneFile=false`** output (`import ... as Types`, `inner?: Types.Inner`) and is asserted by the dedicated `TestGenKclFromGoStructCrossPkg`.
- #577 added `TestGenKclFromGoStruct`, which walks **every** subdirectory of `testdata/gostruct/` and generates with **default** `GenKclOptions`.

The walker therefore also picked up `cross_pkg/`. With default options `OneFile` is `nil` (i.e. `true`), so the generator inlines the external struct as a local schema and the golden comparison fails:

```diff
-import kcl-lang.io.kcl-go.pkg.tools.gen.testdata.gostruct.cross_pkg.types as Types
-    inner?: Types.Inner
+    inner?: TypesInner
+schema TypesInner:   # extra local schema
```

No product code is at fault — one fixture was being consumed by two tests under different options.

## Fix

`TestGenKclFromGoStruct`'s own doc comment already states the convention: *"creating a subdirectory with **input.go** and expect.k"*. `cross_pkg/` uses `main.go`, not `input.go`. The walker now filters on that convention, so fixtures requiring non-default options stay with their dedicated tests.

## Test plan

- [x] `go test ./pkg/tools/gen/ -run TestGenKclFromGoStruct -v` — `basic`, `inline`, `time_fields` pass; `TestGenKclFromGoStructCrossPkg` and `TestGenKclFromGoStructOneFileDefaultsToTrue` still pass
- [x] `go test ./pkg/tools/gen/` — whole package green
- [ ] CI green on all four `build-and-test` matrix jobs

Refs #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)