### PR TITLE
fix(deps): pin toolchain go1.26.6 to fix 21 Go stdlib vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module kcl-lang.io/kcl-go
 
 go 1.26
 
+toolchain go1.26.6
+
 require (
 	github.com/chai2010/jsonv v1.1.3
 	github.com/chai2010/protorpc v1.1.4


### PR DESCRIPTION
## Summary

`govulncheck` reported 21 stdlib vulnerabilities in code paths. The Go 1.26.6
patch release backports fixes for all of them. After this change, 0
vulnerabilities remain in code paths.

## Change

Add `toolchain go1.26.6` to `go.mod` (only file changed).

## Verification

\`\`\`
$ go build ./...
$ govulncheck ./...
Your code is affected by 0 vulnerabilities.
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)